### PR TITLE
Changes to fix "SystemError: Parent module '' not loaded..." in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if sys.platform == 'darwin':
     else:
         extra_compile_args=['-I/System/Library/Frameworks/vecLib.framework/Headers']
 
-    ext_modules = [Extension(name='bh_sne',
+    ext_modules = [Extension(name='tsne.bh_sne',
                    sources=['tsne/bh_sne_src/sptree.cpp', 'tsne/bh_sne_src/tsne.cpp', 'tsne/bh_sne.pyx'],
                    include_dirs=[numpy.get_include(), 'tsne/bh_sne_src/'],
                    extra_compile_args=extra_compile_args + ['-ffast-math', '-O3'],
@@ -42,7 +42,7 @@ if sys.platform == 'darwin':
 else:
     # LINUX
 
-    ext_modules = [Extension(name='bh_sne',
+    ext_modules = [Extension(name='tsne.bh_sne',
                    sources=['tsne/bh_sne_src/sptree.cpp', 'tsne/bh_sne_src/tsne.cpp', 'tsne/bh_sne.pyx'],
                    include_dirs=[numpy.get_include(), '/usr/local/include', 'tsne/bh_sne_src/'],
                    library_dirs=['/usr/local/lib', '/usr/lib64/atlas'],
@@ -50,7 +50,7 @@ else:
                    extra_link_args=['-Wl,-Bstatic', '-lcblas', '-Wl,-Bdynamic'],
                    language='c++'),
 
-                   Extension(name='bh_sne_3d',
+                   Extension(name='tsne.bh_sne_3d',
                    sources=['tsne/bh_sne_src/sptree.cpp', 'tsne/bh_sne_src/tsne.cpp', 'tsne/bh_sne_3d.pyx'],
                    include_dirs=[numpy.get_include(), '/usr/local/include', 'tsne/bh_sne_src/'],
                    library_dirs=['/usr/local/lib', '/usr/lib64/atlas'],

--- a/tsne/__init__.py
+++ b/tsne/__init__.py
@@ -2,9 +2,8 @@
 from __future__ import division
 import numpy as np
 import scipy.linalg as la
-import sys
-from bh_sne import BH_SNE
-from bh_sne_3d import BH_SNE_3D
+from tsne.bh_sne import BH_SNE
+from tsne.bh_sne_3d import BH_SNE_3D
 
 def bh_sne(data, pca_d=None, d=2, perplexity=30., theta=0.5,
            random_state=None, copy_data=False, init=None,


### PR DESCRIPTION
"SystemError: Parent module 'bh-sne' not loaded, cannot perform relative import" error occurs when trying to run this with Python 3.

This fix simply uses absolute imports/naming for the extensions